### PR TITLE
twitter show <id> #552

### DIFF
--- a/src/yetibot/commands/twitter.clj
+++ b/src/yetibot/commands/twitter.clj
@@ -75,7 +75,7 @@
   (-> id
       (model/show)
       (get :body)
-      (model/format-tweet-text)))
+      (model/format-tweet)))
 
 (defn search
   "twitter search <query> # find most recent 20 tweets matching <query>"

--- a/src/yetibot/commands/twitter.clj
+++ b/src/yetibot/commands/twitter.clj
@@ -70,9 +70,12 @@
     (map model/format-tweet-text tweets)))
 
 (defn display
-  "twitter show <id> # display tweet with <id>"
+  "twitter display <id> # display tweet with <id>"
   [{[_ id] :match}]
-  (model/show id))
+  (-> id
+      (model/show)
+      (get :body)
+      (model/format-tweet-text)))
 
 (defn search
   "twitter search <query> # find most recent 20 tweets matching <query>"

--- a/src/yetibot/commands/twitter.clj
+++ b/src/yetibot/commands/twitter.clj
@@ -69,6 +69,10 @@
   (let [tweets (:body (model/user-timeline screen-name 10))]
     (map model/format-tweet-text tweets)))
 
+(defn display
+  "twitter show <id> # display tweet with <id>"
+  [{[_ id] :match}]
+  (model/show id))
 
 (defn search
   "twitter search <query> # find most recent 20 tweets matching <query>"
@@ -98,6 +102,7 @@
     #"^unfollow\s+(.+)" unfollow
     #"^search\s+(.+)" search
     #"^show\s+(\S+)" show
+    #"^display\s+(\d+)" display
     #"^retweet\s+(\d+)" retweet
     #"^reply\s+(\d+)\s+(.+)" reply
     #"^tracking" tracking

--- a/src/yetibot/models/twitter.clj
+++ b/src/yetibot/models/twitter.clj
@@ -186,3 +186,8 @@
                                     :count (if-not (nil? tweet-count)
                                              tweet-count
                                              3)}))
+;;;; show tweet with id
+
+(defn show [id]
+  (statuses-show-id :oauth-creds creds
+                    :params {:id id}))


### PR DESCRIPTION
## Issue #552 

## Goal
 - Feature so that user is able to display a tweet just by the id

Command template is `!twitter  display <id>`

##  Notes
 - Command name `show` was already taken up, so changed command name to `display`
 - tested on a local instance 