### PR TITLE
 Google custom search (images and text) #524 

### DIFF
--- a/config/config-sample.edn
+++ b/config/config-sample.edn
@@ -63,6 +63,10 @@
 
    :s3 {:access-key ""
         :secret-key ""}
+
+   ;; `google`
+   :google {:api-key ""
+            :custom-search-engine-id ""}
    }
 
   :models

--- a/config/config-sample.edn
+++ b/config/config-sample.edn
@@ -66,7 +66,8 @@
 
    ;; `google`
    :google {:api-key ""
-            :custom-search-engine-id ""}
+            :custom-search-engine-id ""
+            :options {}}
    }
 
   :models

--- a/src/yetibot/api/google.clj
+++ b/src/yetibot/api/google.clj
@@ -47,9 +47,8 @@
 ;; map a vector of results to a vector
 ;; of string representations of the results
 (defn format-results
-  [result-body & {:keys [order] :or {order :normal}}]
-    (let [result  (:items result-body)
-          indexed (map-indexed #(vector (inc %1) %2) result)
+  [results & {:keys [order] :or {order :normal}}]
+    (let [indexed (map-indexed #(vector (inc %1) %2) results)
           format  #(str (first %)
                         ". "
                         (format-result (second %) :order order)
@@ -76,7 +75,7 @@
       (catch Exception e
         (warn "Google search returned a failure http status")
         (warn "Google: caught " e)
-        "API Credentials are invalid || Google died"))))
+        nil))))
 
 (defn image-search [q]
   (let [param (select-keys accepted-keywords [:searchType])]

--- a/src/yetibot/api/google.clj
+++ b/src/yetibot/api/google.clj
@@ -17,7 +17,8 @@
 (defonce messages
   {:error-message "Values has to be one of the following: ",
    :no-options-in-config-file  "No google options set in config file."
-   :option-not-found "Option not found"})
+   :option-not-found "Option not found"
+   :extra-set "Can also be set via %s as an extra arg to search command"})
 
 (defonce display-order {:normal [:title :link :snippet]
                         :image  [:title :snippet :link]})
@@ -136,41 +137,217 @@
     {:validation #"^0|1$"
      :error-message (str (:error-message messages) "0,1")
      :info-message "Enables or Disables Simplified and Traditional Chinese Search"
+     :extra (format (:extra-set messages) "--c2c")
      :keyword "c2coff"},
 
    "imgcolortype"
     {:validation #"^mono|gray|color$",
      :error-message (str (:error-message messages) "mono, gray, color")
      :info-message "Returns mono, gray or color images for image-search"
+     :extra (format (:extra-set messages) "-c, --color")
      :keyword "imgColorType"},
 
    "cr"
     {:validation #"^country[A-Z]{2}(:?(:?\|\||&&)country[A-Z]{2})*$"
-     :error-message "Syntax Error: Syntax should be like `countryAB`
-                    or `countryAB&&countryZN`' "
-     :info-message "This paramater restrict dsearch to documents originating
-                   from a certain country"
+     :error-message
+     "Examples of valid input are `countryAB' or `countryAB&&countryZN'"
+     :info-message
+     "This parameter restricts search to documents originating from a certain country"
+     :extra (format (:extra-set messages) "-C, --cr")
      :keyword "cr"},
 
    "filter"
      {:validation #"^0|1$"
       :error-message (str (:error-message messages) "0,1")
       :info-message "Turns off or on duplicate content filter"
+      :extra (format (:extra-set messages) "-f, --filter")
       :keyword "filter"},
 
    "g1"
     {:validation #"^[a-z]{2}$"
-     :error-message "Invalid country code \n
-                     Example of correct code: uk"
-     :info-message "Specifies the geolocation of end-user \n
-                   which would ideally result in location specific results"
+     :error-message "Example of correct input: uk"
+     :info-message
+     (str "Specifies the geolocation of end-user \n"
+          "which would ideally result in location specific results")
+     :extra (format (:extra-set messages) "-g, --g1")
      :keyword "g1"},
-    })
 
-  ;; :g1 #"[a-z]{2}", :googlehost #"google\.(com|[a-z]{2})"
-  ;; :imgDominantColor #"yellow|green|teal|blue|purple|pink|white|gray|black|brown",
-  ;; :imgSize #"clipart|face|lineart|news|photo", :filter #"0|1"
-  ;; :num #"\d|10", :safe #"high|medium|off", :searchType "image"
-  ;; :sort #".*", :start #"\d{1,3}", :siteSearch #".*", :siteSearchFilter #"e|i",
-  ;; :h1 #"[a-z]{2}|zh-Han[s|t]", :hq #".*",
-  ;; })
+   "h1"
+    {:validation #"^[a-z]{2}|zh-Han[s|t]$"
+     :error-message "Valid example is 'fr' for french"
+     :info-message
+     "Specifies the language for the search interface and improves search results."
+     :extra (format (:extra-set messages) "--h1")
+     :keyword "h1"
+    },
+
+   "hq"
+    {:validation #".+"
+     :error-message "Valid input is a non empty string"
+     :info-message "Appends option value to query similar to an AND operator \n"
+     :extra (format (:extra-set messages) "-A,--and")
+     :keyword "hq"
+     },
+
+   "daterestrict"
+    {:validation #"^(?:d|w|m|y)\d+$"
+     :error-message
+     (str "Valid values are of format (d|w|m|y)<number>\n"
+          "d,w,m,y refers to days, weeks, months and years")
+     :info-message
+     "Restricts results to URLS based on date"
+     :extra (format (:extra-set messages) "-d, --date")
+     :keyword "dateRestrict"
+    },
+
+   "excludeterms"
+    {:validation #".+"
+     :error-message "Valid input is a non empty string"
+     :info-message "Identifies a word/phrase that should'nt appear in results\n"
+     :extra (format (:extra-set messages) "-x, --exclude")
+     :keyword "excludeTerms"
+    },
+
+   "exactterms"
+    {:validation #".+"
+     :error-message "Valid input is a non empty string"
+     :info-message "Identifies a word/phrase that should appear in results\n"
+     :extra (format (:extra-set messages) "-e, --exact")
+     :keyword "exactTerms"
+    },
+
+   "highrange"
+    {:validation #"^\d+$"
+     :error-message "Valid input is a number."
+     :info-message  "Specifies the ending valude for a search range"
+     :extra (format (:extra-set messages) "--hr")
+     :keyword "highRange"
+     },
+
+   "lowrange"
+    {:validation #"^\d+$"
+     :error-message "Valid input is a number."
+     :info-message "Specifies the ending valude for a search range"
+     :extra (format (:extra-set messages) "--lr")
+     :keyword "lowRange"
+    },
+
+   "googlehost"
+    {:validation #"^google\.(?:com|[a-z]{2})$"
+     :error-message "Valid values include 'google.de', 'google.fr'"
+     :info-message "Specifies local google domain to perform the search"
+     :extra (format (:extra-set messages) "--ghost")
+     :keyword "keyword"
+     },
+
+   "filetype"
+    {:validation #"^\.\S+$"
+     :error-message "Valid values include '.pdf', '.html', '.clj' etc"
+     :info-message "Restricts results to files of a specific extension"
+     :extra (format (:extra-set messages) "-F, --ft")
+     :keyword "fileType"
+     },
+
+   "imgdominantcolor"
+    {:validation #"^black|blue|brown|gray|green|pink|purple|teal|white|yellow$",
+     :error-message (str (:error-message messages)
+                         "black, blue, brown, gray, green, pink, purple, teal,"
+                         "white, yellow")
+     :info-message "Returns images of a specific dominant color"
+     :extra (format (:extra-set messages) "--dominantcolor")
+     :keyword "imgDominantColor"},
+
+   "imgtype"
+    {:validation ,#"^clipart|face|lineart|news|photo$"
+     :error-message (str (:error-message messages)
+                       "clipart, face, lineart, news, photo")
+     :info-message "Returns images of a specific type"
+     :extra (format (:extra-set messages) "-t, --type")
+     :keyword "imgType"},
+
+   "imgsize"
+    {:validation ,#"^huge|icon|large|medium|small|xlarge|xxlarge$"
+     :error-message (str (:error-message messages)
+                         "huge, icon, large, medium, small,"
+                         "xlarge, xxlarge")
+     :info-message "Returns images of a specific size"
+     :extra (format (:extra-set messages) "-z, --size")
+     :keyword "imgSize"},
+
+   "linksite"
+    {:validation ,#".*"
+     :error-message "Valid input is a website link"
+     :info-message
+     "Specifies all search results should contain a link to a specific site"
+     :extra (format (:extra-set messages) "-l, --link")
+     :keyword "linkSite"},
+
+   "safe"
+    {:validation ,#"^high|medium|off$"
+     :error-message (str (:error-message messages) "high, medium, off")
+     :info-message "Search Safety Level"
+     :extra (format (:extra-set messages) "-o, --safe")
+     :keyword "safe"},
+
+   "relatedsite"
+    {:validation #".*"
+     :error-message "Valid input is a website link"
+     :info-message
+     "Specifies all search results should be pages related to a url"
+     :extra (format (:extra-set messages) "-r, --relsite")
+     :keyword "relatedSite"},
+
+   "sitesearch"
+    {:validation #".*"
+     :error-message "Valid input is a website link"
+     :info-message
+     "Specifies all search results should be pages from a given site"
+     :extra (format (:extra-set messages) "-s, --site")
+     :keyword "siteSearch"},
+
+   "sitesearchfilter"
+    {:validation #"^e|i$"
+     :error-message  (str (:error-message messages) "e, i")
+     :info-message
+     "includes/excludes results from site in siteSearch param"
+     :extra (format (:extra-set messages) "-t, --sitefilter")
+     :keyword "siteSearchFilter"},
+
+   "rights"
+    {:validation #".*"
+     :error-message (str "Supported values include: "
+                         "cc_publicdomain, cc_attribute, cc_sharealike,"
+                         "cc_noncommercial, cc_nonderived"
+                         ", and combinations of these.")
+     :info-message "Filter based on licensing"
+     :extra (format (:extra-set messages) "-i, --license")
+     :keyword "rights"},
+
+   "sort"
+    {:validation #".*"
+     :error-message "Valid input is a nonempty string"
+     :info-message "The sort expression to apply to filters"
+     :extra (format (:extra-set messages) "-q, --sort")
+     :keyword "sort"},
+
+   "num"
+    {:validation #"^\d|10$"
+     :error-message "Valid input is a number between 1 to 10"
+     :info-message "Number of search results to return"
+     :extra (format (:extra-set messages) "-n, --num")
+     :keyword "num"},
+
+   "start"
+    {:validation #"^\d+$"
+     :error-message "Valid input is a number"
+     :info-message "The index of the first result to return"
+     :extra (format (:extra-set messages) "-y, --start")
+     :keyword "start"},
+
+   "orterms"
+    {:validation #".+"
+     :error-message "Valid input is a non empty string"
+     :info-message "Appends option value to query similar to an OR operator "
+     :extra (format (:extra-set messages) "-O,--or")
+     :keyword "orTerms"
+     }})

--- a/src/yetibot/api/google.clj
+++ b/src/yetibot/api/google.clj
@@ -44,7 +44,6 @@
          (remove nil?)
          (s/join "\n"))))
 
-
 (defn format-results
   "map a vector of results to a vector
   of string representations of the results"

--- a/src/yetibot/api/google.clj
+++ b/src/yetibot/api/google.clj
@@ -35,8 +35,8 @@
 (defonce display-order {:normal [:title :link :snippet]
                         :image  [:title :snippet :link]})
 
-;; format a single query result
 (defn format-result
+  "format a single query result"
   [result & {:keys [order] :or {order :normal}}]
   (let [values (display-order order)]
     (->> (select-keys result values)
@@ -44,9 +44,10 @@
          (remove nil?)
          (s/join "\n"))))
 
-;; map a vector of results to a vector
-;; of string representations of the results
+
 (defn format-results
+  "map a vector of results to a vector
+  of string representations of the results"
   [results & {:keys [order] :or {order :normal}}]
     (let [indexed (map-indexed #(vector (inc %1) %2) results)
           format  #(str (first %)
@@ -56,10 +57,10 @@
         (map format indexed)))
 
 (defn search
-  ;; main search function,
-  ;; extra refers to map of extra params to the search api
-  ;; order refers to the the way result is display (look
-  ;; at display-order var)
+  "main search function,
+  extra refers to map of extra params to the search api
+  order refers to the the way result is display (look
+  at display-order var)"
   [q & {:keys [extra order]
         :or {extra {} order :normal}}]
   (info "Google search for: " q)

--- a/src/yetibot/api/google.clj
+++ b/src/yetibot/api/google.clj
@@ -48,8 +48,8 @@
 ;; of string representations of the results
 (defn format-results
   [result-body & {:keys [order] :or {order :normal}}]
-    (let [result (result-body :items)
-          indexed (map vector (range 10) result)
+    (let [result  (:items result-body)
+          indexed (map-indexed #(vector (inc %1) %2) result)
           format  #(str (first %)
                         ". "
                         (format-result (second %) :order order)
@@ -63,10 +63,10 @@
   ;; at display-order var)
   [q & {:keys [extra order]
         :or {extra {} order :normal}}]
-  (info (str "Google search for: " q))
+  (info "Google search for: " q)
   (let [query-params  {:q q
-                       :key (config :api-key)
-                       :cx (config :custom-search-engine-id)}
+                       :key (:api-key config)
+                       :cx (:custom-search-engine-id config)}
         options {:query-params
                  (merge query-params extra)}]
     (try
@@ -75,7 +75,7 @@
         (json/read-json))
       (catch Exception e
         (warn "Google search returned a failure http status")
-        (warn (str "Google: caught " e))
+        (warn "Google: caught " e)
         "API Credentials are invalid || Google died"))))
 
 (defn image-search [q]

--- a/src/yetibot/api/google.clj
+++ b/src/yetibot/api/google.clj
@@ -1,32 +1,18 @@
 (ns yetibot.api.google
   (:require
-   [taoensso.timbre :refer [warn info]]
+   [taoensso.timbre :refer [info warn]]
    [clojure.string :as s]
    [clojure.data.json :as json]
    [clj-http.client :as client]
    [yetibot.core.config :refer [conf-valid? config-for-ns]]))
 
-
 (defonce api-url "https://www.googleapis.com/customsearch/v1?parameters")
 
-(defonce options (atom {}))
-
-(def accepted-keywords {})
-(declare set-option-value)
-
 (defonce messages
-  {:error-message "Values has to be one of the following: ",
-   :no-options-in-config-file  "No google options set in config file."
-   :option-not-found "Option not found"
-   :extra-set "Can also be set via %s as an extra arg to search command"})
+  {:error-message "Values has to be one of the following: "})
 
 (defonce display-order {:normal [:title :link :snippet]
                         :image  [:title :snippet :link]})
-
-;; this is a defn because accepted keywords
-;; is redenfined again towards the bottom
-(defn valid-keywords-list []
-  (keys accepted-keywords))
 
 (def config (config-for-ns))
 
@@ -37,54 +23,7 @@
        (= (count config-values) 2))))
 
 (defn populate-options-from-config []
-  "This loads the custom-engine options set
-  in the config file and load it into the options
-  atom"
-  (let [options (:options config)]
-    (if-not (seq options)
-      (info (:no-options-in-config-file messages))
-      (reduce-kv (fn [_ k v]
-                   (-> (s/trim k)
-                       (s/lower-case)
-                       (set-option-value v)
-                       (info))) [] options))))
-
-(defn- fetch-option-if-exists
-  [option]
-  (get accepted-keywords option))
-
-(defn- validate-option-value
-  [option value]
-  (if-let [option_ (fetch-option-if-exists option)]
-    (re-matches (:validation option_) value)
-    :option-does-not-exist))
-
-(defn set-option-value
-  "This is responsible for checking if
-  a key exists, if it does, it validates the
-  value given"
-  [option value]
-  (condp = (validate-option-value option value)
-    :option-does-not-exist nil
-    nil (get-in accepted-keywords [option :error-message])
-    (do (swap! options
-               assoc (get-in accepted-keywords [option :keyword]) value)
-        (str option " successfully set to " value))))
-
-(defn get-info
-  "Gets info about an option"
-  [option]
-  (:info-message (fetch-option-if-exists option)))
-
-(defn state-of-set-options []
-  "gives back contents of the options
-  atom. If empty gives back nil"
-  (if-not (seq @options)
-    nil
-    @options))
-
-(defn reset-options []
-  (reset! options {}))
+  (:options config))
 
 (defn format-result
   "format a single query result"
@@ -108,15 +47,16 @@
 
 (defn search
   "main search function,
-  extra refers to map of extra params to the search api
+  args refer to map of extra params to the search api
   order refers to the the way result is display (look
-  at display-order var)" [q & {:keys [extra order] :or {extra {} order :normal}}]
+  at display-order var)"
+  [q & {:keys [order args] :or {args {} order :normal}}]
   (info "Google search for: " q)
   (let [query-params  {:q q
                        :key (:api-key config)
                        :cx (:custom-search-engine-id config)}
         options {:query-params
-                 (merge query-params extra @options)}]
+                 (merge query-params args)}]
     (do
       (info options)
     (try
@@ -128,226 +68,200 @@
         (warn "Google: caught " e)
         nil)))))
 
-(defn image-search [q]
+(defn image-search [q & {:keys [args] :or {args {}}}]
   (let [param {"searchType" "image"}]
-    (search q :extra param :order :image)))
+    (search q :order :image
+              :args (merge args param))))
 
 (def accepted-keywords
-  {"c2coff"
+  {:c2coff
     {:validation #"^0|1$"
      :error-message (str (:error-message messages) "0,1")
      :info-message "Enables or Disables Simplified and Traditional Chinese Search"
-     :extra (format (:extra-set messages) "--c2c")
      :keyword "c2coff"},
 
-   "imgcolortype"
+   :imgcolortype
     {:validation #"^mono|gray|color$",
      :error-message (str (:error-message messages) "mono, gray, color")
      :info-message "Returns mono, gray or color images for image-search"
-     :extra (format (:extra-set messages) "-c, --color")
      :keyword "imgColorType"},
 
-   "cr"
+   :cr
     {:validation #"^country[A-Z]{2}(:?(:?\|\||&&)country[A-Z]{2})*$"
      :error-message
      "Examples of valid input are `countryAB' or `countryAB&&countryZN'"
      :info-message
      "This parameter restricts search to documents originating from a certain country"
-     :extra (format (:extra-set messages) "-C, --cr")
      :keyword "cr"},
 
-   "filter"
+   :filter
      {:validation #"^0|1$"
       :error-message (str (:error-message messages) "0,1")
       :info-message "Turns off or on duplicate content filter"
-      :extra (format (:extra-set messages) "-f, --filter")
       :keyword "filter"},
 
-   "g1"
+   :g1
     {:validation #"^[a-z]{2}$"
      :error-message "Example of correct input: uk"
      :info-message
      (str "Specifies the geolocation of end-user \n"
           "which would ideally result in location specific results")
-     :extra (format (:extra-set messages) "-g, --g1")
      :keyword "g1"},
 
-   "h1"
+   :h1
     {:validation #"^[a-z]{2}|zh-Han[s|t]$"
      :error-message "Valid example is 'fr' for french"
      :info-message
      "Specifies the language for the search interface and improves search results."
-     :extra (format (:extra-set messages) "--h1")
      :keyword "h1"
     },
 
-   "hq"
+   :hq
     {:validation #".+"
      :error-message "Valid input is a non empty string"
      :info-message "Appends option value to query similar to an AND operator \n"
-     :extra (format (:extra-set messages) "-A,--and")
      :keyword "hq"
      },
 
-   "daterestrict"
+   :daterestrict
     {:validation #"^(?:d|w|m|y)\d+$"
      :error-message
      (str "Valid values are of format (d|w|m|y)<number>\n"
           "d,w,m,y refers to days, weeks, months and years")
      :info-message
      "Restricts results to URLS based on date"
-     :extra (format (:extra-set messages) "-d, --date")
      :keyword "dateRestrict"
     },
 
-   "excludeterms"
+   :excludeterms
     {:validation #".+"
      :error-message "Valid input is a non empty string"
      :info-message "Identifies a word/phrase that should'nt appear in results\n"
-     :extra (format (:extra-set messages) "-x, --exclude")
      :keyword "excludeTerms"
     },
 
-   "exactterms"
+   :exactterms
     {:validation #".+"
      :error-message "Valid input is a non empty string"
      :info-message "Identifies a word/phrase that should appear in results\n"
-     :extra (format (:extra-set messages) "-e, --exact")
      :keyword "exactTerms"
     },
 
-   "highrange"
+   :highrange
     {:validation #"^\d+$"
      :error-message "Valid input is a number."
      :info-message  "Specifies the ending valude for a search range"
-     :extra (format (:extra-set messages) "--hr")
      :keyword "highRange"
      },
 
-   "lowrange"
+   :lowrange
     {:validation #"^\d+$"
      :error-message "Valid input is a number."
      :info-message "Specifies the ending valude for a search range"
-     :extra (format (:extra-set messages) "--lr")
      :keyword "lowRange"
     },
 
-   "googlehost"
+   :googlehost
     {:validation #"^google\.(?:com|[a-z]{2})$"
      :error-message "Valid values include 'google.de', 'google.fr'"
      :info-message "Specifies local google domain to perform the search"
-     :extra (format (:extra-set messages) "--ghost")
      :keyword "keyword"
      },
 
-   "filetype"
+   :filetype
     {:validation #"^\.\S+$"
      :error-message "Valid values include '.pdf', '.html', '.clj' etc"
      :info-message "Restricts results to files of a specific extension"
-     :extra (format (:extra-set messages) "-F, --ft")
      :keyword "fileType"
      },
 
-   "imgdominantcolor"
+   :imgdominantcolor
     {:validation #"^black|blue|brown|gray|green|pink|purple|teal|white|yellow$",
      :error-message (str (:error-message messages)
                          "black, blue, brown, gray, green, pink, purple, teal,"
                          "white, yellow")
      :info-message "Returns images of a specific dominant color"
-     :extra (format (:extra-set messages) "--dominantcolor")
      :keyword "imgDominantColor"},
 
-   "imgtype"
+   :imgtype
     {:validation ,#"^clipart|face|lineart|news|photo$"
      :error-message (str (:error-message messages)
                        "clipart, face, lineart, news, photo")
      :info-message "Returns images of a specific type"
-     :extra (format (:extra-set messages) "-t, --type")
      :keyword "imgType"},
 
-   "imgsize"
+   :imgsize
     {:validation ,#"^huge|icon|large|medium|small|xlarge|xxlarge$"
      :error-message (str (:error-message messages)
                          "huge, icon, large, medium, small,"
                          "xlarge, xxlarge")
      :info-message "Returns images of a specific size"
-     :extra (format (:extra-set messages) "-z, --size")
      :keyword "imgSize"},
 
-   "linksite"
+   :linksite
     {:validation ,#".*"
      :error-message "Valid input is a website link"
      :info-message
      "Specifies all search results should contain a link to a specific site"
-     :extra (format (:extra-set messages) "-l, --link")
      :keyword "linkSite"},
 
-   "safe"
+   :safe
     {:validation ,#"^high|medium|off$"
      :error-message (str (:error-message messages) "high, medium, off")
      :info-message "Search Safety Level"
-     :extra (format (:extra-set messages) "-o, --safe")
      :keyword "safe"},
 
-   "relatedsite"
+   :relatedsite
     {:validation #".*"
      :error-message "Valid input is a website link"
      :info-message
      "Specifies all search results should be pages related to a url"
-     :extra (format (:extra-set messages) "-r, --relsite")
      :keyword "relatedSite"},
 
-   "sitesearch"
+   :sitesearch
     {:validation #".*"
      :error-message "Valid input is a website link"
      :info-message
      "Specifies all search results should be pages from a given site"
-     :extra (format (:extra-set messages) "-s, --site")
      :keyword "siteSearch"},
 
-   "sitesearchfilter"
+   :sitesearchfilter
     {:validation #"^e|i$"
      :error-message  (str (:error-message messages) "e, i")
      :info-message
      "includes/excludes results from site in siteSearch param"
-     :extra (format (:extra-set messages) "-t, --sitefilter")
      :keyword "siteSearchFilter"},
 
-   "rights"
+   :rights
     {:validation #".*"
      :error-message (str "Supported values include: "
                          "cc_publicdomain, cc_attribute, cc_sharealike,"
                          "cc_noncommercial, cc_nonderived"
                          ", and combinations of these.")
      :info-message "Filter based on licensing"
-     :extra (format (:extra-set messages) "-i, --license")
      :keyword "rights"},
 
-   "sort"
+   :sort
     {:validation #".*"
      :error-message "Valid input is a nonempty string"
      :info-message "The sort expression to apply to filters"
-     :extra (format (:extra-set messages) "-q, --sort")
      :keyword "sort"},
 
-   "num"
+   :num
     {:validation #"^\d|10$"
      :error-message "Valid input is a number between 1 to 10"
      :info-message "Number of search results to return"
-     :extra (format (:extra-set messages) "-n, --num")
      :keyword "num"},
 
-   "start"
+   :start
     {:validation #"^\d+$"
      :error-message "Valid input is a number"
      :info-message "The index of the first result to return"
-     :extra (format (:extra-set messages) "-y, --start")
      :keyword "start"},
 
-   "orterms"
+   :orterms
     {:validation #".+"
      :error-message "Valid input is a non empty string"
      :info-message "Appends option value to query similar to an OR operator "
-     :extra (format (:extra-set messages) "-O,--or")
      :keyword "orTerms"
      }})

--- a/src/yetibot/api/google.clj
+++ b/src/yetibot/api/google.clj
@@ -1,0 +1,57 @@
+(ns yetibot.api.google
+  (:require
+   [taoensso.timbre :refer [info warn error]]
+   [clojure.string :as s]
+   [clojure.data.json :as json]
+   [clj-http.client :as client]
+   [yetibot.core.config :refer [conf-valid? config-for-ns]]))
+
+(def config (config-for-ns))
+(defn configured? [] (conf-valid? config))
+
+(defonce api-url "https://www.googleapis.com/customsearch/v1?parameters")
+
+(defonce keywords (atom {}))
+
+;; validation and documentation
+;; notes : sort needs to be improved upon
+(defonce accepted-keywords
+  {:q #".*", :c2coff #"0|1", :imgColorType #"mono|gray|color",
+   :g1 #"[a-z]{2}", :googlehost #"google\.(com|[a-z]{2})"
+   :imgDominantColor #"yellow|green|teal|blue|purple|pink|white|gray|black|brown",
+   :imgSize #"clipart|face|lineart|news|photo", :filter #"0|1"
+   :num #"\d|10", :safe #"high|medium|off", :searchType "image"
+   :sort #".*", :start #"\d{1,3}", :siteSearch #".*", :siteSearchFilter #"e|i",
+   :h1 #"[a-z]{2}|zh-Han[s|t]", :hq #".*",
+   })
+
+;; format a single query result
+(defn format-result
+  [result]
+  (s/join
+   "\n"
+   (vals (select-keys result [:title :link :snippet]))))
+
+;; map a vector of results to a vector
+;; of string representations of the results
+(defn format-results
+  [result]
+  (if (= (count (result :items)) 0)
+    "Google returned no results"
+    (let [result_ (result :items)
+          indexed (map vector (range 10) result_)
+          format  #(str (first %)
+                        ". "
+                        (format-result (second %))
+                        "\n\n")]
+        (map format indexed))))
+
+(defn vanilla-search [q]
+  (let [options {:query-params
+                 {:q q
+                  :key (config :api-key)
+                  :cx (config :custom-search-engine-id)}}]
+    (-> (client/get api-url options)
+        (get :body)
+        (json/read-json)
+        (format-results))))

--- a/src/yetibot/api/google.clj
+++ b/src/yetibot/api/google.clj
@@ -4,7 +4,7 @@
    [clojure.string :as s]
    [clojure.data.json :as json]
    [clj-http.client :as client]
-   [yetibot.core.config :refer [conf-valid? config-for-ns]]))
+   [yetibot.core.config :refer [conf-valid? get-config]]))
 
 (defonce api-url "https://www.googleapis.com/customsearch/v1?parameters")
 
@@ -14,7 +14,7 @@
 (defonce display-order {:normal [:title :link :snippet]
                         :image  [:title :snippet :link]})
 
-(def config (config-for-ns))
+(def config (get-config :yetibot :api :google))
 
 (defn configured? []
   (let [config-keys   [:api-key :custom-search-engine-id]
@@ -104,8 +104,8 @@
     {:validation #"^[a-z]{2}$"
      :error-message "Example of correct input: uk"
      :info-message
-     (str "Specifies the geolocation of end-user \n"
-          "which would ideally result in location specific results")
+     (str "Specifies the geolocation of end-user"
+          " which would ideally result in location specific results")
      :keyword "g1"},
 
    :h1
@@ -119,14 +119,14 @@
    :hq
     {:validation #".+"
      :error-message "Valid input is a non empty string"
-     :info-message "Appends option value to query similar to an AND operator \n"
+     :info-message "Appends option value to query similar to an AND operator"
      :keyword "hq"
      },
 
    :daterestrict
     {:validation #"^(?:d|w|m|y)\d+$"
      :error-message
-     (str "Valid values are of format (d|w|m|y)<number>\n"
+     (str "Valid values are of format (d|w|m|y)<number> "
           "d,w,m,y refers to days, weeks, months and years")
      :info-message
      "Restricts results to URLS based on date"
@@ -136,14 +136,14 @@
    :excludeterms
     {:validation #".+"
      :error-message "Valid input is a non empty string"
-     :info-message "Identifies a word/phrase that should'nt appear in results\n"
+     :info-message "Identifies a word/phrase that should'nt appear in results"
      :keyword "excludeTerms"
     },
 
    :exactterms
     {:validation #".+"
      :error-message "Valid input is a non empty string"
-     :info-message "Identifies a word/phrase that should appear in results\n"
+     :info-message "Identifies a word/phrase that should appear in results"
      :keyword "exactTerms"
     },
 
@@ -193,7 +193,7 @@
    :imgsize
     {:validation ,#"^huge|icon|large|medium|small|xlarge|xxlarge$"
      :error-message (str (:error-message messages)
-                         "huge, icon, large, medium, small,"
+                         "huge, icon, large, medium, small, "
                          "xlarge, xxlarge")
      :info-message "Returns images of a specific size"
      :keyword "imgSize"},
@@ -235,9 +235,9 @@
    :rights
     {:validation #".*"
      :error-message (str "Supported values include: "
-                         "cc_publicdomain, cc_attribute, cc_sharealike,"
-                         "cc_noncommercial, cc_nonderived"
-                         ", and combinations of these.")
+                         "cc_publicdomain, cc_attribute, cc_sharealike, "
+                         "cc_noncommercial, cc_nonderived, "
+                         "and combinations of these.")
      :info-message "Filter based on licensing"
      :keyword "rights"},
 

--- a/src/yetibot/api/google.clj
+++ b/src/yetibot/api/google.clj
@@ -6,6 +6,27 @@
    [clj-http.client :as client]
    [yetibot.core.config :refer [conf-valid? config-for-ns]]))
 
+
+(defonce api-url "https://www.googleapis.com/customsearch/v1?parameters")
+
+(defonce options (atom {}))
+
+(def accepted-keywords {})
+(declare set-option-value)
+
+(defonce messages
+  {:error-message "Values has to be one of the following: ",
+   :no-options-in-config-file  "No google options set in config file."
+   :option-not-found "Option not found"})
+
+(defonce display-order {:normal [:title :link :snippet]
+                        :image  [:title :snippet :link]})
+
+;; this is a defn because accepted keywords
+;; is redenfined again towards the bottom
+(defn valid-keywords-list []
+  (keys accepted-keywords))
+
 (def config (config-for-ns))
 
 (defn configured? []
@@ -14,26 +35,55 @@
     (and (conf-valid? config)
        (= (count config-values) 2))))
 
-(defonce api-url "https://www.googleapis.com/customsearch/v1?parameters")
+(defn populate-options-from-config []
+  "This loads the custom-engine options set
+  in the config file and load it into the options
+  atom"
+  (let [options (:options config)]
+    (if-not (seq options)
+      (info (:no-options-in-config-file messages))
+      (reduce-kv (fn [_ k v]
+                   (-> (s/trim k)
+                       (s/lower-case)
+                       (set-option-value v)
+                       (info))) [] options))))
 
-;; this has yet to be used somewhere
-(defonce keywords (atom {}))
+(defn- fetch-option-if-exists
+  [option]
+  (get accepted-keywords option))
 
-;; validation and documentation
-;; notes : sort needs to be improved upon
-;; this has yet to be used somwhere
-(defonce accepted-keywords
-  {:q #".*", :c2coff #"0|1", :imgColorType #"mono|gray|color",
-   :g1 #"[a-z]{2}", :googlehost #"google\.(com|[a-z]{2})"
-   :imgDominantColor #"yellow|green|teal|blue|purple|pink|white|gray|black|brown",
-   :imgSize #"clipart|face|lineart|news|photo", :filter #"0|1"
-   :num #"\d|10", :safe #"high|medium|off", :searchType "image"
-   :sort #".*", :start #"\d{1,3}", :siteSearch #".*", :siteSearchFilter #"e|i",
-   :h1 #"[a-z]{2}|zh-Han[s|t]", :hq #".*",
-   })
+(defn- validate-option-value
+  [option value]
+  (if-let [option_ (fetch-option-if-exists option)]
+    (re-matches (:validation option_) value)
+    :option-does-not-exist))
 
-(defonce display-order {:normal [:title :link :snippet]
-                        :image  [:title :snippet :link]})
+(defn set-option-value
+  "This is responsible for checking if
+  a key exists, if it does, it validates the
+  value given"
+  [option value]
+  (condp = (validate-option-value option value)
+    :option-does-not-exist nil
+    nil (get-in accepted-keywords [option :error-message])
+    (do (swap! options
+               assoc (get-in accepted-keywords [option :keyword]) value)
+        (str option " successfully set to " value))))
+
+(defn get-info
+  "Gets info about an option"
+  [option]
+  (:info-message (fetch-option-if-exists option)))
+
+(defn state-of-set-options []
+  "gives back contents of the options
+  atom. If empty gives back nil"
+  (if-not (seq @options)
+    nil
+    @options))
+
+(defn reset-options []
+  (reset! options {}))
 
 (defn format-result
   "format a single query result"
@@ -59,15 +109,15 @@
   "main search function,
   extra refers to map of extra params to the search api
   order refers to the the way result is display (look
-  at display-order var)"
-  [q & {:keys [extra order]
-        :or {extra {} order :normal}}]
+  at display-order var)" [q & {:keys [extra order] :or {extra {} order :normal}}]
   (info "Google search for: " q)
   (let [query-params  {:q q
                        :key (:api-key config)
                        :cx (:custom-search-engine-id config)}
         options {:query-params
-                 (merge query-params extra)}]
+                 (merge query-params extra @options)}]
+    (do
+      (info options)
     (try
       (-> (client/get api-url options)
         (get :body)
@@ -75,8 +125,52 @@
       (catch Exception e
         (warn "Google search returned a failure http status")
         (warn "Google: caught " e)
-        nil))))
+        nil)))))
 
 (defn image-search [q]
-  (let [param (select-keys accepted-keywords [:searchType])]
+  (let [param {"searchType" "image"}]
     (search q :extra param :order :image)))
+
+(def accepted-keywords
+  {"c2coff"
+    {:validation #"^0|1$"
+     :error-message (str (:error-message messages) "0,1")
+     :info-message "Enables or Disables Simplified and Traditional Chinese Search"
+     :keyword "c2coff"},
+
+   "imgcolortype"
+    {:validation #"^mono|gray|color$",
+     :error-message (str (:error-message messages) "mono, gray, color")
+     :info-message "Returns mono, gray or color images for image-search"
+     :keyword "imgColorType"},
+
+   "cr"
+    {:validation #"^country[A-Z]{2}(:?(:?\|\||&&)country[A-Z]{2})*$"
+     :error-message "Syntax Error: Syntax should be like `countryAB`
+                    or `countryAB&&countryZN`' "
+     :info-message "This paramater restrict dsearch to documents originating
+                   from a certain country"
+     :keyword "cr"},
+
+   "filter"
+     {:validation #"^0|1$"
+      :error-message (str (:error-message messages) "0,1")
+      :info-message "Turns off or on duplicate content filter"
+      :keyword "filter"},
+
+   "g1"
+    {:validation #"^[a-z]{2}$"
+     :error-message "Invalid country code \n
+                     Example of correct code: uk"
+     :info-message "Specifies the geolocation of end-user \n
+                   which would ideally result in location specific results"
+     :keyword "g1"},
+    })
+
+  ;; :g1 #"[a-z]{2}", :googlehost #"google\.(com|[a-z]{2})"
+  ;; :imgDominantColor #"yellow|green|teal|blue|purple|pink|white|gray|black|brown",
+  ;; :imgSize #"clipart|face|lineart|news|photo", :filter #"0|1"
+  ;; :num #"\d|10", :safe #"high|medium|off", :searchType "image"
+  ;; :sort #".*", :start #"\d{1,3}", :siteSearch #".*", :siteSearchFilter #"e|i",
+  ;; :h1 #"[a-z]{2}|zh-Han[s|t]", :hq #".*",
+  ;; })

--- a/src/yetibot/commands/google.clj
+++ b/src/yetibot/commands/google.clj
@@ -1,0 +1,17 @@
+(ns yetibot.commands.google
+  (:require
+    [taoensso.timbre :refer [info warn error]]
+    [clojure.string :refer [join]]
+    [yetibot.api.google :as api]
+    [yetibot.core.hooks :refer [cmd-hook suppress]]))
+
+(defn search
+  "google search <query>"
+  [{[_ query] :match}]
+  (api/vanilla-search query))
+
+(if (api/configured?)
+  (cmd-hook #"google"
+            #"^search\s+(.+)" search)
+  (info "Google is not configured."))
+

--- a/src/yetibot/commands/google.clj
+++ b/src/yetibot/commands/google.clj
@@ -1,15 +1,29 @@
 (ns yetibot.commands.google
   (:require
     [taoensso.timbre :refer [info]]
-    [clojure.string :refer [join]]
+    [clojure.string :refer [join trim lower-case]]
     [yetibot.api.google :as api]
     [yetibot.core.hooks :refer [cmd-hook suppress]]))
 
-(def failure-messages
+(api/populate-options-from-config)
+
+(def messages
   {:search "Google returned no results!!"
    :image (str "Google image search returned no results!! \n"
                ".. check your search engine settings")
-   :google-died "API Credentials are invalid || Google died"})
+   :google-died "API Credentials are invalid || Google died"
+   :option-not-found "Option not found"
+   :no-options-set "No options have been set."
+   :reset "Options has been reset"
+   })
+
+(defn no-command-found
+  [_]
+  (str "Command does not exist."
+       " Type in !help google for valid commands"))
+
+(defn clean [str]
+  (trim (lower-case str)))
 
 (defn search
   "google search <query> # plain google search"
@@ -18,8 +32,8 @@
         count (get-in results [:searchInformation
                                :totalResults])]
     (condp = count
-      nil (:google-died failure-messages)
-      "0" (:search failure-messages)
+      nil (:google-died messages)
+      "0" (:search messages)
       (api/format-results (:items results)))))
 
 (defn image-search
@@ -29,12 +43,53 @@
         count (get-in results [:searchInformation
                                :totalResults])]
     (condp = count
-      nil (:google-died failure-messages)
-      "0" (:image failure-messages)
+      nil (:google-died messages)
+      "0" (:image messages)
       (api/format-results (:items results) :order :image))))
+
+(defn option-info
+  "google option-info <query> #display info for option"
+  [{[_ query] :match}]
+  (if-let [info (api/get-info (clean query))]
+    info
+    (:option-not-found messages)))
+
+(defn show-custom-keywords-list
+  "google show options # show list of valid options"
+  [_]
+  (join ", " (api/valid-keywords-list)))
+
+(defn set-option
+  "google set <option> <value>"
+  [{[_ option value] :match}]
+  (if-let [message (api/set-option-value (clean option) value)]
+    message
+    (:option-not-found messages)))
+
+(defn show-set-options
+  "google show set options"
+  [_]
+  (if-let [options-set (api/state-of-set-options)]
+    (->> options-set
+         (map #(str " - " (first %) " has been set to " (second %)))
+         (join "\n"))
+    (:no-options-set messages)))
+
+(defn reset-options
+  "google reset options # current set options are vanquished"
+  [_]
+  (do
+    (api/reset-options)
+    (:reset messages)))
 
 (if (api/configured?)
   (cmd-hook #"google"
             #"^search\s+(.+)" search
-            #"^image\s+(.+)" image-search)
+            #"^image\s+(.+)" image-search
+            #"^option-info\s+(.+)" option-info
+            #"^show\s+options$" show-custom-keywords-list
+            #"^set\s+(\S+)\s+(\S+)" set-option
+            #"^show\s+set\s+options$" show-set-options
+            #"^reset\s+options$" reset-options
+            #".+" no-command-found)
   (info "Google is not configured."))

--- a/src/yetibot/commands/google.clj
+++ b/src/yetibot/commands/google.clj
@@ -9,7 +9,7 @@
   "google search <query> # plain google search"
   [{[_ query] :match}]
   (let [results (api/search query)]
-    (if (= (count (results :items)) 0)
+    (if (= (count (:items results)) 0)
       "Google returned no results!!"
       (api/format-results results))))
 
@@ -17,7 +17,7 @@
   "google image <query> # image search"
   [{[_ query] :match}]
   (let [results (api/image-search query)]
-    (if (= (count (results :items)) 0)
+    (if (= (count (:items results)) 0)
       (str "Google image search returned no results!! \n"
            ".. check your search engine settings")
       (api/format-results results :order :image))))

--- a/src/yetibot/commands/google.clj
+++ b/src/yetibot/commands/google.clj
@@ -1,17 +1,29 @@
 (ns yetibot.commands.google
   (:require
-    [taoensso.timbre :refer [info warn error]]
+    [taoensso.timbre :refer [info]]
     [clojure.string :refer [join]]
     [yetibot.api.google :as api]
     [yetibot.core.hooks :refer [cmd-hook suppress]]))
 
 (defn search
-  "google search <query>"
+  "google search <query> # plain google search"
   [{[_ query] :match}]
-  (api/vanilla-search query))
+  (let [results (api/search query)]
+    (if (= (count (results :items)) 0)
+      "Google returned no results!!"
+      (api/format-results results))))
+
+(defn image-search
+  "google image <query> # image search"
+  [{[_ query] :match}]
+  (let [results (api/image-search query)]
+    (if (= (count (results :items)) 0)
+      (str "Google image search returned no results!! \n"
+           ".. check your search engine settings")
+      (api/format-results results :order :image))))
 
 (if (api/configured?)
   (cmd-hook #"google"
-            #"^search\s+(.+)" search)
+            #"^search\s+(.+)" search
+            #"^image\s+(.+)" image-search)
   (info "Google is not configured."))
-

--- a/src/yetibot/commands/google.clj
+++ b/src/yetibot/commands/google.clj
@@ -5,22 +5,33 @@
     [yetibot.api.google :as api]
     [yetibot.core.hooks :refer [cmd-hook suppress]]))
 
+(def failure-messages
+  {:search "Google returned no results!!"
+   :image (str "Google image search returned no results!! \n"
+               ".. check your search engine settings")
+   :google-died "API Credentials are invalid || Google died"})
+
 (defn search
   "google search <query> # plain google search"
   [{[_ query] :match}]
-  (let [results (api/search query)]
-    (if (= (count (:items results)) 0)
-      "Google returned no results!!"
-      (api/format-results results))))
+  (let [results (api/search query)
+        count (get-in results [:searchInformation
+                               :totalResults])]
+    (condp = count
+      nil (:google-died failure-messages)
+      "0" (:search failure-messages)
+      (api/format-results (:items results)))))
 
 (defn image-search
   "google image <query> # image search"
   [{[_ query] :match}]
-  (let [results (api/image-search query)]
-    (if (= (count (:items results)) 0)
-      (str "Google image search returned no results!! \n"
-           ".. check your search engine settings")
-      (api/format-results results :order :image))))
+  (let [results (api/image-search query)
+        count (get-in results [:searchInformation
+                               :totalResults])]
+    (condp = count
+      nil (:google-died failure-messages)
+      "0" (:image failure-messages)
+      (api/format-results (:items results) :order :image))))
 
 (if (api/configured?)
   (cmd-hook #"google"

--- a/src/yetibot/commands/google.clj
+++ b/src/yetibot/commands/google.clj
@@ -1,11 +1,42 @@
 (ns yetibot.commands.google
   (:require
     [taoensso.timbre :refer [info]]
-    [clojure.string :refer [join trim lower-case]]
+    [clojure.string :refer [join trim lower-case split]]
+    [clojure.tools.cli :refer [parse-opts]]
     [yetibot.api.google :as api]
     [yetibot.core.hooks :refer [cmd-hook suppress]]))
 
-(api/populate-options-from-config)
+(defonce options (atom {}))
+
+(defonce cli-args
+  {:c2coff       [nil "--c2c"],     :imgcolortype ["-c" "--color"],
+   :cr           ["-C" "--cr"],     :filter       ["-f" "--filter"],
+   :g1           ["-g" "--g1"],     :h1           [nil "--h1"],
+   :hq           ["-A" "--and"],    :daterestrict ["-d" "--date"],
+   :excludeterms ["-x" "--exclude"],:exactterms   ["-e" "--exact"],
+   :highrange    [nil "--hr"],      :lowrange     [nil "--lr"],
+   :googlehost   [nil "--ghost"],   :filetype     ["-F" " --ft"],
+   :imgtype      ["-t" "--type"],   :imgsize      ["-z"  "--size"],
+   :linksite     ["-l"  "--link"],  :safe         ["-o" "--safe"],
+   :relatedsite  ["-r" "--relsite"],:sitesearch   ["-s" "--site"],
+   :rights       ["-i" "--license"],:sort         ["-q" "--sort"],
+   :num          ["-n" " --num"],   :start        ["-y" "--start"],
+   :imgdominantcolor [nil "--dominantcolor"],
+   :sitesearchfilter ["-t" "--sitefilter"],
+   :orterms          ["-O" "--or"],
+  })
+
+(defonce valid-keywords-list
+  (keys cli-args))
+
+(defonce built-cli-options
+  (reduce-kv
+   (fn [m k v]
+     (conj m (conj (k cli-args) (:info-message v)
+                   :id k
+                   :validate [#(re-matches (:validation v) %)
+                              (:error-message v)])))
+   [] api/accepted-keywords))
 
 (def messages
   {:search "Google returned no results!!"
@@ -15,61 +46,134 @@
    :option-not-found "Option not found"
    :no-options-set "No options have been set."
    :reset "Options has been reset"
+   :empty-query "Query cannot be left empty"
+   :invalid-args "Check options given"
+   :com-not-found  (str "Command does not exist."
+                        " Type in !help google for valid commands")
+   :no-options-in-config-file  "No google options set in config file."
    })
 
-(defn no-command-found
-  [_]
-  (str "Command does not exist."
-       " Type in !help google for valid commands"))
+(defn command-not-found [_]
+  (:com-not-found messages))
 
-(defn clean [str]
-  (trim (lower-case str)))
+(defn- state-of-set-options []
+  "gives back contents of the options
+  atom. If empty gives back nil"
+  (if-not (seq @options)
+    nil
+    @options))
+
+(defn- fetch-option-if-exists
+  [option]
+  (get api/accepted-keywords option))
+
+(defn- validate-option-value
+  [option value]
+  (if-let [option_ (fetch-option-if-exists option)]
+    (re-matches (:validation option_) value)
+    :option-does-not-exist))
+
+(defn- set-option-value
+  "This is responsible for checking if
+  a key exists, if it does, it validates the
+  value given"
+  [option value]
+  (condp = (validate-option-value option value)
+    :option-does-not-exist nil
+    nil (get-in api/accepted-keywords [option :error-message])
+    (do (swap! options
+               assoc option value)
+        (str option " successfully set to " value))))
+
+(defn get-info
+  "Gets info about an option"
+  [option]
+  (if-let [value (fetch-option-if-exists option)]
+    (:info-message value)))
+
+(defn convert-keys-into-google-keywords
+  [obj]
+  (reduce-kv (fn [m k v]
+               (assoc m
+                      (get-in api/accepted-keywords [k :keyword]) v)) {}))
+
+(defn options-processor [string]
+  (let [output (parse-opts string built-cli-options)]
+    (if-let [error-messages (:errors output)]
+      {:errors error-messages}
+      {:query (join " " (:arguments output))
+       :args (convert-keys-into-google-keywords (:options output))})))
+
+(defn common-search-function
+  [query & {:keys [order sfunction]
+   :or {order :normal sfunction api/search}}]
+  (let [proc-query (options-processor query)]
+    (cond
+      (empty? (:query proc-query)) (:empty-query messages)
+      (:errors proc-query) (join "\n" (:errors proc-query))
+      :else
+      (let [args (:args proc-query)
+            results (sfunction (:query proc-query)
+                               :args (merge @options args))
+            count (get-in results [:searchInformation
+                                   :totalResults])]
+        (condp = count
+          nil (:google-died messages)
+          "0" (:search messages)
+          (api/format-results (:items results) :order order))))))
 
 (defn search
   "google search <query> # plain google search"
   [{[_ query] :match}]
-  (let [results (api/search query)
-        count (get-in results [:searchInformation
-                               :totalResults])]
-    (condp = count
-      nil (:google-died messages)
-      "0" (:search messages)
-      (api/format-results (:items results)))))
+  ()
+  (common-search-function query))
 
 (defn image-search
   "google image <query> # image search"
   [{[_ query] :match}]
-  (let [results (api/image-search query)
-        count (get-in results [:searchInformation
-                               :totalResults])]
-    (condp = count
-      nil (:google-died messages)
-      "0" (:image messages)
-      (api/format-results (:items results) :order :image))))
+  (common-search-function query
+                          :sfunction api/image-search
+                          :order :image))
 
+(defn- load-options-from-file-into-atom
+  []
+  (let [options  (api/populate-options-from-config)]
+    (if (empty? options)
+      (info (:no-options-in-config-file messages))
+      (doall (map (fn [[k v]]
+                    (if-let [result (set-option-value k v)]
+                      (info result)
+                      (info k ":" (:option-not-found messages))))
+                  options)))))
+
+(load-options-from-file-into-atom)
+(defonce copy-of-valid-file-options
+  @options)
+
+;; stay
 (defn option-info
   "google option-info <query> #display info for option"
   [{[_ query] :match}]
-  (if-let [info (api/get-info (clean query))]
+  (if-let [info (get-info (keyword query))]
     info
     (:option-not-found messages)))
 
 (defn show-custom-keywords-list
   "google show options # show list of valid options"
   [_]
-  (join ", " (api/valid-keywords-list)))
+  (join ", " (map name valid-keywords-list)))
 
 (defn set-option
   "google set <option> <value>"
   [{[_ option value] :match}]
-  (if-let [message (api/set-option-value (clean option) value)]
+  (if-let [message (set-option-value (keyword option) value)]
     message
     (:option-not-found messages)))
 
 (defn show-set-options
   "google show set options"
   [_]
-  (if-let [options-set (api/state-of-set-options)]
+  (if-let [options-set (state-of-set-options)]
     (->> options-set
          (map #(str " - " (first %) " has been set to " (second %)))
          (join "\n"))
@@ -79,8 +183,13 @@
   "google reset options # current set options are vanquished"
   [_]
   (do
-    (api/reset-options)
+    (reset! options {})
     (:reset messages)))
+
+(defn restore-options
+  "google restore options # restore from file config"
+  [_]
+  (reset! options copy-of-valid-file-options))
 
 (if (api/configured?)
   (cmd-hook #"google"
@@ -91,5 +200,6 @@
             #"^set\s+(\S+)\s+(\S+)" set-option
             #"^show\s+set\s+options$" show-set-options
             #"^reset\s+options$" reset-options
-            #".+" no-command-found)
+            #"^restore\s+options$" restore-options
+            #".+" command-not-found)
   (info "Google is not configured."))

--- a/test/yetibot/test/api/google.clj
+++ b/test/yetibot/test/api/google.clj
@@ -1,0 +1,82 @@
+(ns yetibot.test.api.google
+  (:require
+   [clojure.test :refer :all]
+   [clj-http.client :as client]
+   [clojure.data.json :as json]
+   [yetibot.api.google :as api]
+   ))
+
+(defonce test-call-response
+   {:items [{:title "x-files"
+            :link  "httbs://yyy.x-files.com"
+            :snippet "Best paranormal series staring Davi..."
+            :image "httbs://yyy.hot-picture-of-danna-scully.com"},
+           {:title "wilfred"
+            :link "httbs://yyy.wilfred-smashing-ryan.com"
+            :snippet "The sun is an attention grabbing whore.."
+            :image "httbs://yyy.wilfred-smoking-bong.com"}]})
+
+(defonce test-items (:items test-call-response))
+(defonce test-call-response-json
+  {:body (json/write-str test-call-response)})
+
+(deftest empty-config-configured?-test
+  (with-redefs-fn
+    {#'api/config {}}
+    #(is (= (api/configured?)
+            false))))
+
+(deftest config-with-one-key-configured?-test
+  "should return false, as both
+   keys are required for the configuration
+   for the search engine"
+  (with-redefs-fn
+    {#'api/config {:api-key "something"}}
+    #(is (= (api/configured?)
+            false))))
+
+(deftest config-with-two-keys-configured?-test
+  "should return true, as both
+   keys (correct keys) are present"
+  (with-redefs-fn
+    {#'api/config {:api-key "something"
+                   :custom-search-engine-id "something"}}
+    #(is (= (api/configured?)
+            true))))
+
+(deftest format-result-normal-order-test
+  (let [test-data (nth test-items 0)]
+    (is (= (api/format-result test-data)
+           (str (:title test-data)
+                "\n" (:link test-data)
+                "\n" (:snippet test-data))))))
+
+(deftest format-result-image-order-test
+  (let [test-data (nth test-items 0)]
+    (is (= (api/format-result test-data :order :image)
+           (str (:title test-data)
+                "\n" (:snippet test-data)
+                "\n" (:link test-data))))))
+
+(deftest format-results-normal-order-test
+  (is (= (api/format-results test-items)
+         [(str "1. " (api/format-result (nth test-items 0)) "\n\n")
+          (str "2. " (api/format-result (nth test-items 1)) "\n\n")])))
+
+(deftest format-results-image-order-test
+  (is (= (api/format-results test-items :order :image)
+         [(str "1. " (api/format-result (nth test-items 0)
+                                        :order :image) "\n\n")
+          (str "2. " (api/format-result (nth test-items 1)
+                                        :order :image) "\n\n")])))
+
+(deftest search-test
+  (with-redefs-fn
+    {#'client/get (fn [_ & _] test-call-response-json)}
+    #(is (= (api/search "query")
+            test-call-response))))
+
+(deftest search-test-with-bad-http-return
+  (with-redefs-fn
+    {#'client/get (fn [_ & _] (throw (Exception. "Bad return")))}
+    #(is (nil? (api/search "query")))))

--- a/test/yetibot/test/commands/google.clj
+++ b/test/yetibot/test/commands/google.clj
@@ -105,7 +105,7 @@
 
 (deftest state-of-set-options-test
   (with-redefs-fn
-    {#'command/options (atom {:wilfred "demigod"})}
+    {#'command/options-atom (atom {:wilfred "demigod"})}
     #(is (not (empty? (command/state-of-set-options))))))
 
 (deftest empty-state-of-set-options-test
@@ -116,7 +116,7 @@
         val "mono"
         keyword (get-in api/accepted-keywords [key :keyword])]
     (with-redefs-fn
-      {#'command/options (atom {})
+      {#'command/options-atom (atom {})
        #'api/populate-options-from-config (fn [] {key val})}
       #(is (= (do (command/load-options-from-file-into-atom)
-                  @command/options) {keyword val})))))
+                  @command/options-atom) {keyword val})))))

--- a/test/yetibot/test/commands/google.clj
+++ b/test/yetibot/test/commands/google.clj
@@ -1,0 +1,53 @@
+(ns yetibot.test.commands.google
+  (:require
+   [clojure.test :refer :all]
+   [yetibot.commands.google :as command]
+   [yetibot.api.google :as api]
+   ))
+
+(defonce test-call-response
+  {:items [{:title "x-files"
+            :link  "httbs://yyy.x-files.com"
+            :snippet "Best paranormal series staring Davi..."},
+           {:title "wilfred"
+            :link "httbs://yyy.wilfred-smashing-ryan.com"
+            :snippet "The sun is an attention grabbing whore.."}]
+   :searchInformation {:totalResults "2"}})
+
+(defonce no-results-response {:searchInformation {:totalResults "0"}})
+
+(deftest command-search-no-results-test
+  (with-redefs-fn
+    {#'api/search (fn [_] no-results-response)}
+    #(is (= (command/search {:match ["" "something"]})
+            (:search command/failure-messages)))))
+
+(deftest command-image-search-no-results-test
+  (with-redefs-fn
+    {#'api/image-search (fn [_] no-results-response)}
+    #(is (= (command/image-search {:match ["" "something"]})
+            (:image command/failure-messages)))))
+
+(deftest command-search-bad-response-test
+  (with-redefs-fn
+    {#'api/search (fn [_] nil)}
+    #(is (= (command/search {:match ["" "something"]})
+            (:google-died command/failure-messages)))))
+
+(deftest command-image-search-bad-response-test
+  (with-redefs-fn
+    {#'api/image-search (fn [_] nil)}
+    #(is (= (command/image-search {:match ["" "something"]})
+            (:google-died command/failure-messages)))))
+
+(deftest command-search-test
+  (with-redefs-fn
+    {#'api/search (fn [_] test-call-response)}
+    #(is (= (command/search {:match ["" "something"]})
+            (api/format-results (:items test-call-response))))))
+
+(deftest command-image-search-test
+  (with-redefs-fn
+    {#'api/image-search (fn [_] test-call-response)}
+    #(is (= (command/image-search {:match ["" "something"]})
+            (api/format-results (:items test-call-response) :order :image)))))

--- a/test/yetibot/test/commands/google.clj
+++ b/test/yetibot/test/commands/google.clj
@@ -20,25 +20,25 @@
   (with-redefs-fn
     {#'api/search (fn [_] no-results-response)}
     #(is (= (command/search {:match ["" "something"]})
-            (:search command/failure-messages)))))
+            (:search command/messages)))))
 
 (deftest command-image-search-no-results-test
   (with-redefs-fn
     {#'api/image-search (fn [_] no-results-response)}
     #(is (= (command/image-search {:match ["" "something"]})
-            (:image command/failure-messages)))))
+            (:image command/messages)))))
 
 (deftest command-search-bad-response-test
   (with-redefs-fn
     {#'api/search (fn [_] nil)}
     #(is (= (command/search {:match ["" "something"]})
-            (:google-died command/failure-messages)))))
+            (:google-died command/messages)))))
 
 (deftest command-image-search-bad-response-test
   (with-redefs-fn
     {#'api/image-search (fn [_] nil)}
     #(is (= (command/image-search {:match ["" "something"]})
-            (:google-died command/failure-messages)))))
+            (:google-died command/messages)))))
 
 (deftest command-search-test
   (with-redefs-fn

--- a/test/yetibot/test/commands/google.clj
+++ b/test/yetibot/test/commands/google.clj
@@ -18,36 +18,36 @@
 
 (deftest command-search-no-results-test
   (with-redefs-fn
-    {#'api/search (fn [_] no-results-response)}
+    {#'api/search (fn [_ & _] no-results-response)}
     #(is (= (command/search {:match ["" "something"]})
             (:search command/messages)))))
 
 (deftest command-image-search-no-results-test
   (with-redefs-fn
-    {#'api/image-search (fn [_] no-results-response)}
+    {#'api/image-search (fn [_ & _] no-results-response)}
     #(is (= (command/image-search {:match ["" "something"]})
             (:image command/messages)))))
 
 (deftest command-search-bad-response-test
   (with-redefs-fn
-    {#'api/search (fn [_] nil)}
+    {#'api/search (fn [_ & _] nil)}
     #(is (= (command/search {:match ["" "something"]})
             (:google-died command/messages)))))
 
 (deftest command-image-search-bad-response-test
   (with-redefs-fn
-    {#'api/image-search (fn [_] nil)}
+    {#'api/image-search (fn [_ & _] nil)}
     #(is (= (command/image-search {:match ["" "something"]})
             (:google-died command/messages)))))
 
 (deftest command-search-test
   (with-redefs-fn
-    {#'api/search (fn [_] test-call-response)}
+    {#'api/search (fn [_ & _] test-call-response)}
     #(is (= (command/search {:match ["" "something"]})
             (api/format-results (:items test-call-response))))))
 
 (deftest command-image-search-test
   (with-redefs-fn
-    {#'api/image-search (fn [_] test-call-response)}
+    {#'api/image-search (fn [_ & _] test-call-response)}
     #(is (= (command/image-search {:match ["" "something"]})
             (api/format-results (:items test-call-response) :order :image)))))


### PR DESCRIPTION
## Goal

To create  `google` commands that is able to search both text and images. 
Users should also be able to customize the search engine via the config file.
User should  be able to put in cli type options while using the `search` and `image` (image search command)
User should be able to set options for search via the appropriate commands 

## Accompilshed
- `google search <query>` returns at-most 10 results (because of custom engine API limitation) with a `title`,`link` and `snippet` for each result.
-   `google image <query>` now searches for images based on what the query is. The image results are displayed in a different order than the vanilla search one due to rendering weirdness on slack
- config is checked for the existence of two keys in existence in addition  to the config-validation function  that exists in `yeti.core` 
- messages are displayed to the user if no results are found
- warning messages are displayed on the server (where the yetibot is running) console in case google returns messages with http failure status codes.
- cli type options can now be put in `search` and `image` commands 
- options can be set via the config file or (inclusive) via the commands on the chat frontend.
- options can be completely rest via the commandline or (inclusive) also be restored to the existing values set in the config file, again via the commands on the frontend.
- options that have been set can be viewed on the chat frontend

## how to test
1. run yetibot locally and have it access slack correctly
2. remove google search engine credentials, restart yetibot and check to see if it logs out that `Google is not configured`
3. Add-in one of the two keys-value pairs ,restart yetibot and verify you see that the message `Google is not configured` is outputted to the console
4. Put in incorrect credentials (for api-key and custom-search-engine-id) and run yetibot and try to enter something like `!google search digimon` (on slack) and you should given the `API credentials are invalid || google died` message. Also check your console for info messages.
5. Put in the correct credentials but keep the `image search` setting disabled and restart yetibot, this time `!google search digimon` should give you results but `!google image digimon` should give you the message `Google image search returned no results!! ... check your search engine settings` 
6. Once you enable the image search part, a query like `!google image ehhdfskjsfdfsdjfhkjh87dhfjksdhjkds` should return the same message as mentioned above ("Google image returned ..... please...)
7. `!google search fshsfdhfshsfdjh8978978sfdjksfdhkh` should return the message `"Google returned no results!!"`
8. Put in in-valid option values in the config file and restart yetibot
9. Validation errors should appear on the terminal output while the yetibot starts up
10. putting in `google show set options` should show `No options have been set`
11. for a list of options that can be set via the chat frontend enter in `google show options`
12. Try getting info on the commands that you can see as a result of entering the above command
13. Try setting options via the `!google set <option> <value>`
14. Try to make sure sure your search results reflect the options you have set
15. Reset these options by entering the command `!google reset options`
16. Now try entering options via option arguments to the search functions and verify the correctness of the search results. 

## for credentials
1. Have a google/gmail account
2. go here https://cse.google.com/cse/all