### PR TITLE
code for issue #563

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,6 +29,8 @@
 
                  ; [incanter "1.4.0"]
 
+                 ;for polling
+                 [robert/bruce "0.8.0"]
                  ]
   :plugins [[lein-exec "0.3.5"]
             [lein-cloverage "1.0.7-SNAPSHOT"]

--- a/test/yetibot/test/commands/github.clj
+++ b/test/yetibot/test/commands/github.clj
@@ -1,0 +1,31 @@
+(ns yetibot.test.commands.github
+  (:require
+   [clojure.test :refer :all]
+   [yetibot.commands.github :refer [stats-cmd]]
+   [yetibot.api.github :as gh]))
+
+(def dummy-poll-counter (atom 0))
+(def mock-poll-result {:a 1 :d 1 :c 1 :con 4})
+(def mock-repo-info ["wilfred" "tv"])
+
+(defn mock-stats-fn [_ _]
+  (if (= @dummy-poll-counter 2)
+    mock-poll-result
+    (swap! dummy-poll-counter inc)))
+
+(deftest test-stats-cmd-polling-no-response
+  (with-redefs-fn
+    {#'gh/sum-stats (fn [_ _] nil)}
+    #(is (= (stats-cmd {:match (cons "dummy" mock-repo-info)})
+            (apply format
+                   "Crunching the latest data for `%s/%s`, try again in a few moments 🐌"
+                   mock-repo-info)))))
+
+(deftest test-stats-cmd-polling-success-response
+  (with-redefs-fn
+    {#'gh/sum-stats mock-stats-fn}
+    #(is (= (stats-cmd {:match (cons "dummy" mock-repo-info)})
+            (apply format
+                   "%s/%s: %s commits, %s additions, %s deletions, %s contributors"
+             (into mock-repo-info (vals mock-poll-result)))))))
+


### PR DESCRIPTION
## Goal ##
To make sure the `gh stats` polls for the contributor stats in the scenario
github requires time to process/crunch the stats numbers

## Pull request added changes ##
 - gh stats is now a polling function with a set number of tries
   after which the function gives up and outputs the existing
   try-after-some-time message
 - tests are in order for the polling for the stats feature
 - project dependencies now include robert bruce (the intelligent polling library)

## How to test ##
-  Add some organization like `Netflix` to your `orgs` list in the `config.edn`
- start yetibot
- `gh repos Netflix` to get a list of all their repos 
- randomly samply a few off the above mentioned list and run `gh stats` on them
- Expected results are the ui should take a few seconds more than usual to get back to you with the stats if you do not see an (almost) instantaneous response

