### PR TITLE
Add  Missing '}'

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -15,7 +15,7 @@ A very minimal config would be:
                         :username "my-yetibot",
                         :host "chat.freenode.net",
                         :port "7070",
-                        :ssl "true"}}}
+                        :ssl "true"}}}}
 ```
 
 This instructs Yetibot to join freenode with the username `my-yetibot` (change

--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -11,7 +11,7 @@ A very minimal config would be:
 
 ```clojure
 {:yetibot
-  :adapters {:freenode {:type "irc",
+  {:adapters {:freenode {:type "irc",
                         :username "my-yetibot",
                         :host "chat.freenode.net",
                         :port "7070",


### PR DESCRIPTION
Without the closing '}' I get an error:

`ERROR [yetibot.core.util.config:29] - Failed loading config:  java.lang.RuntimeException: Map literal must contain an even number of forms`

Referenced in #627