### PR TITLE
Fix For Issue #620

### DIFF
--- a/src/yetibot/commands/json.clj
+++ b/src/yetibot/commands/json.clj
@@ -17,7 +17,10 @@
   "json <url> # parse json from <url>"
   [{[url] :match}]
   (info "json" url)
-  (:body (client/get url {:as :json})))
+  (-> (client/get url)
+      :body
+      (clojure.string/replace  #"\uFEFF" "")
+      json/read-str))
 
 (defn json-parse-cmd
   "json parse <json>"


### PR DESCRIPTION
-Idea from: mmazi/rescu#54

Not sure if this is something that clj-http should be stripping out
on their end? This might just be a hack, and there is a better way
to go about this?

Also, adding [cheshire] as a dependency might fix it as well, although when I
tried that, it still gave the same error (cheshire is a dependency
of clj-http when using the :as :json feature of clj-http/get
see [here](https://github.com/dakrone/clj-http#optional-dependencies) )