### PR TITLE
Add convertion to keywords in json parse command

### DIFF
--- a/src/yetibot/commands/json.clj
+++ b/src/yetibot/commands/json.clj
@@ -25,7 +25,7 @@
 (defn json-parse-cmd
   "json parse <json>"
   [{[_ text] :match}]
-  (json/read-str text))
+  (json/read-str text :key-fn keyword))
 
 (cmd-hook #"json"
   #"path\s+(.+)" json-path-cmd

--- a/test/yetibot/test/commands/json.clj
+++ b/test/yetibot/test/commands/json.clj
@@ -1,0 +1,8 @@
+(ns yetibot.test.commands.json
+  (:require
+    [clojure.test :refer :all]
+    [yetibot.commands.json :refer :all]))
+
+(deftest test-should-convert-keys-to-keywords-when-parsing-json
+  (let [args {:match ["" "{\"key\": \"value\"}"]}]
+    (is (= (json-parse-cmd args) {:key "value"}))))


### PR DESCRIPTION
Add convertion to keywords in json parse command to allow use with `curl` and `json path` commands.

Ex.: `!curl url | json parse | json path $..words`

Without the keywords commands. It was generating the parsed json with the following structure:
`{key "value"}`
And when trying to use `json path`, the command didn't work well.